### PR TITLE
Fix logic issue with garage door. 

### DIFF
--- a/athom-garage-door.yaml
+++ b/athom-garage-door.yaml
@@ -99,11 +99,21 @@ cover:
     name: "${friendly_name}"
     lambda: "return id(contact).state ? COVER_OPEN : COVER_CLOSED;"
     open_action:
-      - switch.turn_on: relay
+      then:
+        - if:
+            condition:
+              lambda: 'return id(contact).state == false;'
+            then:
+              - switch.turn_on: relay
     stop_action:
       - switch.turn_on: relay
     close_action:
-      - switch.turn_on: relay
+      then:
+        - if:
+            condition:
+              lambda: 'return id(contact).state == true;'
+            then:
+              - switch.turn_on: relay
 
 text_sensor:
   - platform: wifi_info

--- a/athom-garage-door.yaml
+++ b/athom-garage-door.yaml
@@ -2,7 +2,7 @@ substitutions:
   name: "athom-garage-door"
   friendly_name: "Athom Garage Door"
   project_name: "athom.garage-door"
-  project_version: "1.0"
+  project_version: "1.1"
 
 esphome:
   name: "${name}"

--- a/athom-garage-door.yaml
+++ b/athom-garage-door.yaml
@@ -102,7 +102,7 @@ cover:
       then:
         - if:
             condition:
-              lambda: 'return id(contact).state == false;'
+              lambda: 'return !id(contact).state;'
             then:
               - switch.turn_on: relay
     stop_action:
@@ -111,7 +111,7 @@ cover:
       then:
         - if:
             condition:
-              lambda: 'return id(contact).state == true;'
+              lambda: 'return id(contact).state;'
             then:
               - switch.turn_on: relay
 


### PR DESCRIPTION
In home assistant if the garage door is closed and you call cover.close on the entity it will open the garage.  The expected functionality is that nothing will happen as the garage is already closed. 

In home assistant if the garage door is open and you call cover.open on the entity it will close the garage.  The expected functionality is that nothing will happen as the garage is already open. 

This pull request adds a check in each command to make this function as expected. 