### PR TITLE
Update athom-smart-plug-v2.yaml

### DIFF
--- a/athom-smart-plug-v2.yaml
+++ b/athom-smart-plug-v2.yaml
@@ -16,6 +16,9 @@ esp8266:
   board: esp8285
   restore_from_flash: true
 
+preferences:
+  flash_write_interval: 3min
+
 api:
 
 ota:
@@ -94,7 +97,6 @@ sensor:
   - platform: total_daily_energy
     name: "${friendly_name} Total Daily Energy"
     restore: true
-    min_save_interval: 180s
     power_id: power_sensor
     unit_of_measurement: kWh
     accuracy_decimals: 3


### PR DESCRIPTION
Breaking change: ´min_save_interval’ was removed in 2022.6.0. Please use the ‘preferences’ → ‘flash_write_interval’ to adjust --> Change to accomodate...